### PR TITLE
feat: add fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ from other modules, forcing qualified functions.
 - [`NoUnqualifiedFunctions`](NoUnqualifiedFunctions)
 
 
+## Automatic Fixes
+
+The rule provides a fix that will add qualifiers to each unqualified function.
+
+Note that this fix will leave the `exposing ()` section of import statements
+unchanged; the fixes in [jfmengels/review-unused] can remove them.
+
+[jfmengels/review-unused]: https://package.elm-lang.org/packages/jfmengels/review-unused/latest/NoUnused-Variables
+
+
 ## Configuration
 
 ```elm

--- a/elm.json
+++ b/elm.json
@@ -10,10 +10,9 @@
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
         "elm/core": "1.0.5 <= v < 2.0.0",
-        "jfmengels/elm-review": "2.4.0 <= v < 3.0.0",
+        "elm-community/dict-extra": "2.4.0 <= v < 3.0.0",
+        "jfmengels/elm-review": "2.13.0 <= v < 3.0.0",
         "stil4m/elm-syntax": "7.2.1 <= v < 8.0.0"
     },
-    "test-dependencies": {
-        "elm-explorations/test": "1.2.2 <= v < 2.0.0"
-    }
+    "test-dependencies": {}
 }

--- a/elm.json
+++ b/elm.json
@@ -11,7 +11,7 @@
     "dependencies": {
         "elm/core": "1.0.5 <= v < 2.0.0",
         "elm-community/dict-extra": "2.4.0 <= v < 3.0.0",
-        "jfmengels/elm-review": "2.13.0 <= v < 3.0.0",
+        "jfmengels/elm-review": "2.13.1 <= v < 3.0.0",
         "stil4m/elm-syntax": "7.2.1 <= v < 8.0.0"
     },
     "test-dependencies": {

--- a/elm.json
+++ b/elm.json
@@ -14,5 +14,7 @@
         "jfmengels/elm-review": "2.13.0 <= v < 3.0.0",
         "stil4m/elm-syntax": "7.2.1 <= v < 8.0.0"
     },
-    "test-dependencies": {}
+    "test-dependencies": {
+        "elm-explorations/test": "2.0.1 <= v < 3.0.0"
+    }
 }

--- a/preview/elm.json
+++ b/preview/elm.json
@@ -1,0 +1,37 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src",
+        "../src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.5",
+            "elm-community/dict-extra": "2.4.0",
+            "jfmengels/elm-review": "2.13.0",
+            "stil4m/elm-syntax": "7.2.9"
+        },
+        "indirect": {
+            "elm/bytes": "1.0.8",
+            "elm/html": "1.0.0",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/project-metadata-utils": "1.0.2",
+            "elm/random": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/virtual-dom": "1.0.3",
+            "elm-community/list-extra": "8.7.0",
+            "elm-explorations/test": "2.1.1",
+            "miniBill/elm-unicode": "1.0.3",
+            "rtfeldman/elm-hex": "1.0.0",
+            "stil4m/structured-writer": "1.0.3"
+        }
+    },
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "2.1.1"
+        },
+        "indirect": {}
+    }
+}

--- a/preview/src/ReviewConfig.elm
+++ b/preview/src/ReviewConfig.elm
@@ -1,0 +1,21 @@
+module ReviewConfig exposing (config)
+
+{-| Do not rename the ReviewConfig module or the config function, because
+`elm-review` will look for these.
+
+To add packages that contain rules, add them to this review project using
+
+    `elm install author/packagename`
+
+when inside the directory containing this file.
+
+-}
+
+import NoUnqualifiedFunctions
+import Review.Rule exposing (Rule)
+
+
+config : List Rule
+config =
+    [ NoUnqualifiedFunctions.rule
+    ]

--- a/src/NoUnqualifiedFunctions.elm
+++ b/src/NoUnqualifiedFunctions.elm
@@ -6,18 +6,37 @@ module NoUnqualifiedFunctions exposing (rule)
 
 -}
 
+import Dict exposing (Dict)
+import Dict.Extra as DE
 import Elm.Syntax.Exposing as Exposing
+import Elm.Syntax.Expression exposing (Expression(..))
 import Elm.Syntax.Import exposing (Import)
 import Elm.Syntax.Module as Module exposing (Module)
+import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node as Node exposing (Node)
-import Review.Rule as Rule exposing (Rule, Error)
+import Elm.Syntax.Range exposing (Range)
+import Review.Fix as Fix exposing (Fix)
+import Review.Rule as Rule exposing (Error, Rule)
 
 
 type alias Context =
-    String
+    { currentModuleName : String
+    , fixesToApplyByPrefix : Dict String (List Fix)
+    , importErrorsByPrefix : Dict String ( { message : String, details : List String }, Range )
+    , prefixesToApplyByName : Dict String { matchModule : String, prefix : String }
+    }
+
+
+type alias AboutEachImportExpression =
+    { errorIngredients : ( { message : String, details : List String }, Range )
+    , searchFor : String
+    , matchModule : String
+    , prefixWith : String
+    }
 
 
 {-| Reports when a module imports functions from other modules.
+
 
 ## Fail
 
@@ -37,60 +56,297 @@ type alias Context =
 -}
 rule : Rule
 rule =
-    Rule.newModuleRuleSchema "NoUnqualifiedFunctions" ""
+    Rule.newModuleRuleSchema "NoUnqualifiedFunctions"
+        { currentModuleName = ""
+        , fixesToApplyByPrefix = Dict.empty
+        , importErrorsByPrefix = Dict.empty
+        , prefixesToApplyByName = Dict.empty
+        }
         |> Rule.withModuleDefinitionVisitor moduleDefinitionVisitor
-        |> Rule.withImportVisitor importVisitor
+        |> Rule.withImportVisitor (importVisitor |> createsNoErrorsHere)
+        |> Rule.withExpressionEnterVisitor (createFixesForUsages |> createsNoErrorsHere)
+        |> Rule.withFinalModuleEvaluation matchFixesUpToImportErrors
+        |> Rule.providesFixesForModuleRule
         |> Rule.fromModuleRuleSchema
+
+
+createsNoErrorsHere : (Node a -> Context -> Context) -> Node a -> Context -> ( List (Error {}), Context )
+createsNoErrorsHere visitor node context =
+    ( [], visitor node context )
 
 
 moduleDefinitionVisitor : Node Module -> Context -> ( List (Error {}), Context )
 moduleDefinitionVisitor node context =
     ( []
-    , Node.value node |> Module.moduleName |> String.join "."
+    , { context
+        | currentModuleName = Node.value node |> Module.moduleName |> String.join "."
+      }
     )
 
 
-importVisitor : Node Import -> Context -> ( List (Error {}), Context )
-importVisitor node currentModule =
-    ( case
+importVisitor : Node Import -> Context -> Context
+importVisitor node oldContext =
+    case
         Node.value node
             |> .exposingList
             |> Maybe.map Node.value
-      of
+    of
         Just (Exposing.Explicit nodes) ->
-            List.foldl
-                (\exposeNode errors ->
+            let
+                pairWithErrors :
+                    Node Exposing.TopLevelExpose
+                    -> List AboutEachImportExpression
+                    -> List AboutEachImportExpression
+                pairWithErrors exposeNode errors =
                     case Node.value exposeNode of
                         Exposing.FunctionExpose funName ->
                             let
+                                nodeValue =
+                                    Node.value node
+
                                 importedModule : String
                                 importedModule =
-                                    Node.value node
-                                        |> .moduleName
+                                    nodeValue.moduleName
                                         |> Node.value
                                         |> String.join "."
+
+                                importedAlias =
+                                    nodeValue.moduleAlias
+                                        |> Maybe.map
+                                            (Node.value >> String.join ".")
+
+                                args =
+                                    { importModule = importedModule
+                                    , importAlias = importedAlias
+                                    , functionName = funName
+                                    }
                             in
                             (::)
-                                (Rule.error
-                                    { message = "Importing functions is not allowed. Use qualified names instead."
-                                    , details = [ detailsMessage currentModule importedModule funName ]
-                                    }
-                                    (Node.range node)
-                                )
+                                { errorIngredients =
+                                    ( { message = "Importing functions is not allowed. Use qualified names instead."
+                                      , details = [ detailsMessage oldContext args ]
+                                      }
+                                    , Node.range node
+                                      {- Should we provide a fix here for the import expression?
+
+                                         Or... do we let the `NoUnused` rule handle it? 😈
+                                      -}
+                                    )
+                                , searchFor = funName
+                                , matchModule = importedModule
+                                , prefixWith = importedAlias |> Maybe.withDefault importedModule
+                                }
                                 errors
 
                         _ ->
                             errors
-                )
-                []
-                nodes
+
+                flattenIntoContext :
+                    AboutEachImportExpression
+                    -> Context
+                    -> Context
+                flattenIntoContext new accContext =
+                    { accContext
+                        | importErrorsByPrefix =
+                            accContext.importErrorsByPrefix
+                                |> Dict.insert new.prefixWith new.errorIngredients
+                        , prefixesToApplyByName =
+                            accContext.prefixesToApplyByName
+                                |> Dict.insert new.searchFor
+                                    { matchModule = new.matchModule
+                                    , prefix = new.prefixWith
+                                    }
+                    }
+            in
+            -- could probably do both folds in a single pass...
+            nodes
+                |> List.foldl pairWithErrors []
+                |> List.foldl flattenIntoContext oldContext
 
         _ ->
-            []
-    , currentModule
-    )
+            oldContext
 
 
-detailsMessage : String -> String -> String -> String
-detailsMessage moduleName importModule functionName =
-    "'" ++ moduleName ++ "' imports '" ++ functionName ++ "' from '" ++ importModule ++ "'."
+createFixesForUsages : Node Expression -> Context -> Context
+createFixesForUsages node oldContext =
+    case Node.value node |> onlyFunctionNames of
+        Nothing ->
+            oldContext
+
+        Just ( functionModuleName, functionName ) ->
+            case oldContext.prefixesToApplyByName |> Dict.get functionName of
+                Just { matchModule, prefix } ->
+                    let
+                        flattenedFunctionModuleName =
+                            String.join "." functionModuleName
+
+                        ignoreBecauseAlreadyQualified =
+                            flattenedFunctionModuleName == matchModule
+
+                        ignoreBecauseDifferentModule =
+                            flattenedFunctionModuleName /= ""
+                    in
+                    if ignoreBecauseAlreadyQualified then
+                        oldContext
+
+                    else if ignoreBecauseDifferentModule then
+                        oldContext
+
+                    else
+                        {- is not qualified; we should fix it(?)
+
+                           This function or value _might_ be shadowing the one
+                           we want to change!
+                           How do we tell that we shouldn't change it?
+
+                               import Foo exposing (baz)
+
+                               baz "This baz should be qualified"
+
+                               f baz =
+                                 baz "This baz should NOT be qualified"
+                        -}
+                        let
+                            range =
+                                Node.range node
+
+                            target =
+                                prefix ++ "." ++ functionName
+
+                            combineFixLists : List Fix -> List Fix -> List Fix
+                            combineFixLists oldValue newValue =
+                                newValue ++ oldValue
+                        in
+                        { oldContext
+                            | fixesToApplyByPrefix =
+                                oldContext.fixesToApplyByPrefix
+                                    |> DE.insertDedupe combineFixLists prefix [ Fix.replaceRangeBy range target ]
+                        }
+
+                Nothing ->
+                    oldContext
+
+
+matchFixesUpToImportErrors : Context -> List (Error {})
+matchFixesUpToImportErrors context =
+    let
+        matchHelper :
+            ( String, ( { message : String, details : List String }, Range ) )
+            -> Error {}
+        matchHelper ( prefix, ingredients ) =
+            let
+                ( info, range {- , importFix -} ) =
+                    ingredients
+
+                usageFixes : Maybe (List Fix)
+                usageFixes =
+                    context.fixesToApplyByPrefix |> Dict.get prefix
+
+                fixes =
+                    case usageFixes of
+                        Just usages ->
+                            -- importFix ::
+                            usages
+
+                        Nothing ->
+                            [{- return only the importFix here -}]
+            in
+            Rule.errorWithFix info range fixes
+    in
+    context.importErrorsByPrefix
+        |> Dict.toList
+        |> List.map matchHelper
+
+
+onlyFunctionNames : Expression -> Maybe ( ModuleName, String )
+onlyFunctionNames node =
+    case node of
+        Application _ ->
+            Nothing
+
+        CaseExpression _ ->
+            Nothing
+
+        CharLiteral _ ->
+            Nothing
+
+        Floatable _ ->
+            Nothing
+
+        FunctionOrValue moduleName name ->
+            Just ( moduleName, name )
+
+        GLSLExpression _ ->
+            Nothing
+
+        Hex _ ->
+            Nothing
+
+        IfBlock _ _ _ ->
+            Nothing
+
+        Integer _ ->
+            Nothing
+
+        LambdaExpression _ ->
+            Nothing
+
+        LetExpression _ ->
+            Nothing
+
+        ListExpr _ ->
+            Nothing
+
+        Literal _ ->
+            Nothing
+
+        Negation _ ->
+            Nothing
+
+        Operator _ ->
+            Nothing
+
+        OperatorApplication _ _ _ _ ->
+            Nothing
+
+        ParenthesizedExpression _ ->
+            Nothing
+
+        PrefixOperator _ ->
+            Nothing
+
+        RecordAccess _ _ ->
+            Nothing
+
+        RecordAccessFunction _ ->
+            Nothing
+
+        RecordExpr _ ->
+            Nothing
+
+        RecordUpdateExpression _ _ ->
+            Nothing
+
+        TupledExpression _ ->
+            Nothing
+
+        UnitExpr ->
+            Nothing
+
+
+detailsMessage : Context -> { importModule : String, importAlias : Maybe String, functionName : String } -> String
+detailsMessage context { importModule, importAlias, functionName } =
+    let
+        targetName =
+            importModule ++ "." ++ functionName
+
+        targetAlias =
+            case importAlias of
+                Just alias ->
+                    " (alias " ++ alias ++ ")"
+
+                Nothing ->
+                    ""
+    in
+    ("'" ++ context.currentModuleName ++ "' imports '" ++ functionName ++ "' from '" ++ importModule ++ "'")
+        ++ ("\n Uses of " ++ functionName ++ " should be replaced with " ++ targetName ++ targetAlias ++ ".")

--- a/src/NoUnqualifiedFunctions.elm
+++ b/src/NoUnqualifiedFunctions.elm
@@ -165,7 +165,6 @@ importVisitor node oldContext =
                                     }
                     }
             in
-            -- could probably do both folds in a single pass...
             nodes
                 |> List.foldl pairWithErrors []
                 |> List.foldl flattenIntoContext oldContext
@@ -231,7 +230,7 @@ matchFixesUpToImportErrors context =
             -> Error {}
         matchHelper ( prefix, ingredients ) =
             let
-                ( info, range {- , importFix -} ) =
+                ( info, range ) =
                     ingredients
 
                 usageFixes : Maybe (List Fix)
@@ -241,11 +240,10 @@ matchFixesUpToImportErrors context =
                 fixes =
                     case usageFixes of
                         Just usages ->
-                            -- importFix ::
                             usages
 
                         Nothing ->
-                            [{- return only the importFix here -}]
+                            []
             in
             Rule.errorWithFix info range fixes
     in

--- a/src/NoUnqualifiedFunctions.elm
+++ b/src/NoUnqualifiedFunctions.elm
@@ -138,10 +138,6 @@ importVisitor node oldContext =
                                       , details = [ detailsMessage oldContext args ]
                                       }
                                     , Node.range node
-                                      {- Should we provide a fix here for the import expression?
-
-                                         Or... do we let the `NoUnused` rule handle it? 😈
-                                      -}
                                     )
                                 , searchFor = funName
                                 , matchModule = importedModule

--- a/tests/NoUnqualifiedFunctionsTest.elm
+++ b/tests/NoUnqualifiedFunctionsTest.elm
@@ -126,7 +126,6 @@ a =
                             |> RT.whenFixed """module A exposing (..)
 
 import B exposing (someValue)
-import B.C as C
 
 a =
     let

--- a/tests/NoUnqualifiedFunctionsTest.elm
+++ b/tests/NoUnqualifiedFunctionsTest.elm
@@ -1,0 +1,75 @@
+module NoUnqualifiedFunctionsTest exposing (all)
+
+import NoUnqualifiedFunctions as NUF
+import Review.Test as RT
+import Test as T exposing (Test)
+
+
+all : Test
+all =
+    T.describe "NoUnqualifiedFunctions"
+        [ T.test "should not report an error when only types and operators are imported" <|
+            \() ->
+                """module A exposing (..)
+
+import B exposing (SomeType, (</>))
+
+a = 1
+"""
+                    |> RT.run NUF.rule
+                    |> RT.expectNoErrors
+        , T.test "should report an error when a function or value is imported" <|
+            \() ->
+                """module A exposing (..)
+
+import B exposing (someValue)
+
+a = someValue 1
+"""
+                    |> RT.run NUF.rule
+                    |> RT.expectErrors
+                        [ RT.error
+                            { message = "Importing functions is not allowed. Use qualified names instead."
+                            , details =
+                                [ "'A' imports 'someValue' from 'B'\n Uses of someValue should be replaced with B.someValue."
+                                ]
+                            , under = "import B exposing (someValue)"
+                            }
+                            |> RT.whenFixed """module A exposing (..)
+
+import B exposing (someValue)
+
+a = B.someValue 1
+"""
+                        ]
+        , T.test "applying the fix should NOT apply incorrect prefixes to shadowed variables of the same name" <|
+            \() ->
+                """module A exposing (..)
+
+import B exposing (someValue)
+
+a = someValue 1
+
+b someValue =
+    someValue 2
+"""
+                    |> RT.run NUF.rule
+                    |> RT.expectErrors
+                        [ RT.error
+                            { message = "Importing functions is not allowed. Use qualified names instead."
+                            , details =
+                                [ "'A' imports 'someValue' from 'B'\n Uses of someValue should be replaced with B.someValue."
+                                ]
+                            , under = "import B exposing (someValue)"
+                            }
+                            |> RT.whenFixed """module A exposing (..)
+
+import B exposing (someValue)
+
+a = B.someValue 1
+
+b someValue =
+    someValue 2
+"""
+                        ]
+        ]


### PR DESCRIPTION
# Problem

On a huge codebase, it's a lot of work to find and fix the unqualified usages that this rule guards against.

# Solution

Supply a Fix that will qualify the usages.

~~Note that **the fix may have false-positives,** and add incorrect qualifications to functions or values that coincidentally have the same name as an imported function. Hence the "dirty" in the title.~~ Should be fine now!

Even then, implementing this dirty Fix and cleaning up the resulting errors was **much** faster than any alternative I could think of, on our 160k+ LoC project.